### PR TITLE
Initialise cluster server client members to avoid initialisation exceptions 

### DIFF
--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -38,6 +38,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
                 self._channel_credentials = grpc.ssl_channel_credentials(root_ca.read())
         else:
             self._channel_credentials = grpc.ssl_channel_credentials()
+        self._channel, self._stub = None, None # Prevent missing members
         self._channel, self._stub = self.new_channel_and_stub()
         self._databases = _TypeDBDatabaseManagerImpl(self.stub())
         self._is_open = True


### PR DESCRIPTION
## What is the goal of this PR?
We initialise the members of the cluster server client class to prevent 'has no attribute' exceptions in 'is None' checks

## What are the changes implemented in this PR?
* Initialise _ClusterServerClient.{_channel, _stub} to None to prevent `AttributeError: '_ClusterServerClient' object has no attribute '_stub'` exceptions when checking `self._stub is None`