### PR TITLE
Safer cluster channel initialisation & better handling of invalid token errors 

### DIFF
--- a/typedb/common/exception.py
+++ b/typedb/common/exception.py
@@ -44,6 +44,8 @@ class TypeDBClientException(Exception):
             return TypeDBClientException(msg=UNABLE_TO_CONNECT, cause=rpc_error)
         elif rpc_error.code() is StatusCode.INTERNAL and "[RPL01]" in str(rpc_error):
             return TypeDBClientException(msg=CLUSTER_REPLICA_NOT_PRIMARY, cause=None)
+        elif rpc_error.code() is StatusCode.UNAUTHENTICATED and "[CLS08]" in str(rpc_error):
+            return TypeDBClientException(msg=CLUSTER_TOKEN_CREDENTIAL_INVALID, cause=None)
         elif rpc_error.code() is StatusCode.INTERNAL:
             return TypeDBClientException(msg=rpc_error.details(), cause=None)
         else:

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -38,7 +38,6 @@ class _ClusterServerClient(_TypeDBClientImpl):
                 self._channel_credentials = grpc.ssl_channel_credentials(root_ca.read())
         else:
             self._channel_credentials = grpc.ssl_channel_credentials()
-        self._channel, self._stub = None, None # Prevent missing members
         self._channel, self._stub = self.new_channel_and_stub()
         self._databases = _TypeDBDatabaseManagerImpl(self.stub())
         self._is_open = True
@@ -61,7 +60,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
             self._channel_credentials,
             grpc.metadata_call_credentials(_CredentialAuth(
                 credential=self._credential,
-                token_fn=lambda: None if self._stub is None else self._stub.token()
+                token_fn=lambda: None if (not hasattr(self, '_stub') or self._stub is None) else self._stub.token()
             ))
         )
         return grpc.secure_channel(self._address, combined_credentials)

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -38,6 +38,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
                 self._channel_credentials = grpc.ssl_channel_credentials(root_ca.read())
         else:
             self._channel_credentials = grpc.ssl_channel_credentials()
+        self._channel, self._stub = None, None # Prevent missing members
         self._channel, self._stub = self.new_channel_and_stub()
         self._databases = _TypeDBDatabaseManagerImpl(self.stub())
         self._is_open = True


### PR DESCRIPTION
## What is the goal of this PR?
When setting up a Check that the `_stub` attribute exists before we check if its value is `None`. We also update the way we handle expired tokens.

## What are the changes implemented in this PR?
* Do a `hasattr` check before `self._stub is None` check in `_ClusterClient._new_channel`
* Wrap errors where the server rejects authentication because the provided token is not (or no longer) valid.